### PR TITLE
Add tests for page components and recipe generator dialog

### DIFF
--- a/src/tests/components/recipe-generator-dialog.test.tsx
+++ b/src/tests/components/recipe-generator-dialog.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { RecipeGeneratorDialog } from '../../components/RecipeGeneratorDialog';
+import { renderWithProviders } from '../setup';
+
+vi.mock('../../hooks/useFoodInventory');
+vi.mock('../../hooks/useTags');
+vi.mock('../../hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('../../components/ui/grouped-multi-select', () => ({
+  GroupedMultiSelect: ({ onValueChange }: any) => (
+    <button onClick={() => onValueChange(['item1'])}>Select Ingredient</button>
+  ),
+}));
+vi.mock('../../lib/servingUnitUtils', () => ({
+  calculateRecipeNutrition: vi.fn(() => ({
+    calories_per_serving: 100,
+    protein_per_serving: 10,
+    carbs_per_serving: 20,
+    fat_per_serving: 5,
+  })),
+}));
+
+import * as inventoryHook from '../../hooks/useFoodInventory';
+import * as tagsHook from '../../hooks/useTags';
+
+describe('RecipeGeneratorDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(inventoryHook.useFoodInventory).mockReturnValue({
+      allItems: [{ id: 'item1', name: 'Tomato', in_stock: true }],
+    } as any);
+    vi.mocked(tagsHook.useTags).mockReturnValue({
+      allTags: [{ id: 'tag1', name: 'Vegan' }],
+    } as any);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'AI Salad',
+                instructions: 'Mix ingredients.',
+                servings: 2,
+                total_time_minutes: 10,
+                ingredients: [
+                  { ingredient_name: 'Tomato', quantity: 1, unit: 'pieces' },
+                ],
+                tags: ['Vegan'],
+              }),
+            },
+          },
+        ],
+      }),
+    } as any);
+  });
+
+  it('generates a recipe and calls onRecipeGenerated when accepted', async () => {
+    const onRecipeGenerated = vi.fn();
+    renderWithProviders(
+      <RecipeGeneratorDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onRecipeGenerated={onRecipeGenerated}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Select Ingredient'));
+    fireEvent.click(screen.getByRole('button', { name: /generate recipe/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    await screen.findByText('AI Salad');
+
+    fireEvent.click(screen.getByRole('button', { name: /accept & save recipe/i }));
+
+    expect(onRecipeGenerated).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'AI Salad' })
+    );
+  });
+});

--- a/src/tests/pages/analytics-page.test.tsx
+++ b/src/tests/pages/analytics-page.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import Analytics from '../../pages/Analytics';
+import { renderWithProviders } from '../setup';
+import * as mealLogsHook from '../../hooks/useMealLogs';
+import * as inventoryHook from '../../hooks/useFoodInventory';
+
+vi.mock('../../hooks/useMealLogs');
+vi.mock('../../hooks/useFoodInventory');
+vi.mock('../../components/Layout', () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+describe('Analytics Page', () => {
+  it('renders analytics summary', () => {
+    vi.mocked(mealLogsHook.useMealLogs).mockReturnValue({
+      mealLogs: [],
+      getRecentMealLogs: () => [],
+      usingMockData: false,
+      loading: false,
+      error: null,
+      addMealLog: vi.fn(),
+      updateMealLog: vi.fn(),
+      deleteMealLog: vi.fn(),
+      reLogMeal: vi.fn(),
+      getMealLogsByDateRange: vi.fn(),
+      refetch: vi.fn(),
+    } as any);
+
+    vi.mocked(inventoryHook.useFoodInventory).mockReturnValue({
+      allItems: [],
+      usingMockData: false,
+      loading: false,
+      error: null,
+    } as any);
+
+    renderWithProviders(<Analytics />);
+
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Top Categories')).toBeInTheDocument();
+  });
+});

--- a/src/tests/pages/index-page.test.tsx
+++ b/src/tests/pages/index-page.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import Index from '../../pages/Index';
+import { renderWithProviders } from '../setup';
+import * as inventoryHook from '../../hooks/useFoodInventory';
+
+vi.mock('../../hooks/useFoodInventory');
+vi.mock('../../components/Layout', () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+vi.mock('../../components/FoodItemCard', () => ({
+  FoodItemCard: ({ item }: any) => <div>{item.name}</div>,
+}));
+
+describe('Index Page', () => {
+  beforeEach(() => {
+    vi.mocked(inventoryHook.useFoodInventory).mockReturnValue({
+      items: [{ id: '1', name: 'Apple', category: 'Fruit', in_stock: true, rating: 0 }],
+      searchQuery: '',
+      setSearchQuery: vi.fn(),
+      performSearch: vi.fn(),
+      categoryFilter: 'all',
+      setCategoryFilter: vi.fn(),
+      stockFilter: 'all',
+      setStockFilter: vi.fn(),
+      ratingFilter: 'all',
+      setRatingFilter: vi.fn(),
+      categories: ['Fruit'],
+      addItem: vi.fn(),
+      updateItem: vi.fn(),
+      deleteItem: vi.fn(),
+      toggleStock: vi.fn(),
+      usingMockData: true,
+      error: null,
+    } as any);
+  });
+
+  it('renders inventory item', () => {
+    renderWithProviders(<Index />);
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+  });
+});

--- a/src/tests/pages/inventory-page.test.tsx
+++ b/src/tests/pages/inventory-page.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../setup';
+import { InventoryPage } from '../../components/InventoryPage';
+import * as inventoryHook from '../../hooks/useFoodInventory';
+
+vi.mock('../../hooks/useFoodInventory');
+vi.mock('../../components/FoodItemCard', () => ({
+  FoodItemCard: ({ item, onToggleStock, onEdit, onDelete }: any) => (
+    <div>
+      <span>{item.name}</span>
+      <button onClick={onToggleStock}>toggle</button>
+      <button onClick={onEdit}>edit</button>
+      <button onClick={onDelete}>delete</button>
+    </div>
+  ),
+}));
+vi.mock('../../components/AddEditItemDialog', () => ({
+  AddEditItemDialog: ({ onSave }: any) => (
+    <button
+      onClick={() =>
+        onSave({ id: '2', name: 'Banana', category: 'Fruit', in_stock: true, rating: 0 })
+      }
+    >
+      save item
+    </button>
+  ),
+}));
+
+
+describe('Inventory Page', () => {
+  let addItem: any;
+  let updateItem: any;
+  let deleteItem: any;
+  let toggleStock: any;
+
+  beforeEach(() => {
+    addItem = vi.fn();
+    updateItem = vi.fn();
+    deleteItem = vi.fn();
+    toggleStock = vi.fn();
+
+    vi.mocked(inventoryHook.useFoodInventory).mockReturnValue({
+      items: [{ id: '1', name: 'Apple', category: 'Fruit', in_stock: true, rating: 0 }],
+      searchQuery: '',
+      setSearchQuery: vi.fn(),
+      performSearch: vi.fn(),
+      categoryFilter: 'all',
+      setCategoryFilter: vi.fn(),
+      stockFilter: 'all',
+      setStockFilter: vi.fn(),
+      ratingFilter: 'all',
+      setRatingFilter: vi.fn(),
+      categories: ['Fruit'],
+      addItem,
+      updateItem,
+      deleteItem,
+      toggleStock,
+      usingMockData: false,
+      error: null,
+    } as any);
+  });
+
+  it('creates an item', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<InventoryPage />);
+    await user.click(screen.getByText('save item'));
+    expect(addItem).toHaveBeenCalledWith({
+      id: '2',
+      name: 'Banana',
+      category: 'Fruit',
+      in_stock: true,
+      rating: 0,
+    });
+  });
+
+  it('updates an item', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<InventoryPage />);
+    await user.click(screen.getByText('edit'));
+    await user.click(screen.getByText('save item'));
+    expect(updateItem).toHaveBeenCalledWith('1', {
+      id: '2',
+      name: 'Banana',
+      category: 'Fruit',
+      in_stock: true,
+      rating: 0,
+    });
+  });
+
+  it('deletes an item', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<InventoryPage />);
+    await user.click(screen.getByText('delete'));
+    expect(deleteItem).toHaveBeenCalledWith('1');
+  });
+
+  it('toggles stock status', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<InventoryPage />);
+    await user.click(screen.getByText('toggle'));
+    expect(toggleStock).toHaveBeenCalledWith('1');
+  });
+});
+

--- a/src/tests/pages/meal-prep-generator-page.test.tsx
+++ b/src/tests/pages/meal-prep-generator-page.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import MealPrepGenerator from '../../pages/MealPrepGenerator';
+import { renderWithProviders } from '../setup';
+import * as inventoryHook from '../../hooks/useFoodInventory';
+import * as recipesHook from '../../hooks/useRecipes';
+import * as tagsHook from '../../hooks/useTags';
+
+vi.mock('../../hooks/useFoodInventory');
+vi.mock('../../hooks/useRecipes');
+vi.mock('../../hooks/useTags');
+vi.mock('../../hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('../../components/Layout', () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+vi.mock('@/components/ui/multi-select', () => ({
+  MultiSelect: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/grouped-multi-select', () => ({
+  GroupedMultiSelect: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig();
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+describe('MealPrepGenerator Page', () => {
+  it('renders heading', () => {
+    vi.mocked(inventoryHook.useFoodInventory).mockReturnValue({ allItems: [] } as any);
+    vi.mocked(recipesHook.useRecipes).mockReturnValue({ addRecipe: vi.fn() } as any);
+    vi.mocked(tagsHook.useTags).mockReturnValue({ allTags: [] } as any);
+
+    renderWithProviders(<MealPrepGenerator />);
+    expect(screen.getByText('Meal Prep Generator')).toBeInTheDocument();
+  });
+});

--- a/src/tests/pages/meals-page.test.tsx
+++ b/src/tests/pages/meals-page.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import Meals from '../../pages/Meals';
+import { renderWithProviders } from '../setup';
+import * as mealLogsHook from '../../hooks/useMealLogs';
+import * as recipesHook from '../../hooks/useRecipes';
+
+vi.mock('../../hooks/useMealLogs');
+vi.mock('../../hooks/useRecipes');
+vi.mock('../../hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('../../components/Layout', () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+vi.mock('../../components/LogMealDialog', () => ({ LogMealDialog: () => null }));
+vi.mock('../../components/ConfirmDialog', () => ({ ConfirmDialog: () => null }));
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: any) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: any) => <div>{children}</div>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe('Meals Page', () => {
+  it('renders meal logs', () => {
+    vi.mocked(mealLogsHook.useMealLogs).mockReturnValue({
+      mealLogs: [{
+        id: 1,
+        meal_name: 'Pasta',
+        date: '2024-01-01',
+        recipe_ids: [],
+        notes: '',
+        nutrition: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+        estimated_cost: 0,
+      }],
+      addMealLog: vi.fn(),
+      updateMealLog: vi.fn(),
+      deleteMealLog: vi.fn(),
+      reLogMeal: vi.fn(),
+      usingMockData: true,
+      error: null,
+      loading: false,
+      getMealLogsByDateRange: vi.fn(),
+      getRecentMealLogs: vi.fn(),
+      refetch: vi.fn(),
+    } as any);
+
+    vi.mocked(recipesHook.useRecipes).mockReturnValue({
+      getRecipeById: vi.fn(),
+    } as any);
+
+    renderWithProviders(<Meals />);
+    expect(screen.getByText('Meal Log')).toBeInTheDocument();
+    expect(screen.getByText('Pasta')).toBeInTheDocument();
+  });
+});

--- a/src/tests/pages/not-found-page.test.tsx
+++ b/src/tests/pages/not-found-page.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import NotFound from '../../pages/NotFound';
+import { renderWithProviders } from '../setup';
+
+describe('NotFound Page', () => {
+  it('shows 404 message', () => {
+    renderWithProviders(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Oops! Page not found')).toBeInTheDocument();
+  });
+});

--- a/src/tests/pages/recipes-page.test.tsx
+++ b/src/tests/pages/recipes-page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import Recipes from '../../pages/Recipes';
+import { renderWithProviders } from '../setup';
+import * as recipesHook from '../../hooks/useRecipes';
+import * as inventoryHook from '../../hooks/useFoodInventory';
+import * as tagsHook from '../../hooks/useTags';
+
+vi.mock('../../hooks/useRecipes');
+vi.mock('../../hooks/useFoodInventory');
+vi.mock('../../hooks/useTags');
+vi.mock('../../hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('../../components/Layout', () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+vi.mock('../../components/AddRecipeDialog', () => ({ AddRecipeDialog: () => null }));
+vi.mock('../../components/RecipeGeneratorDialog', () => ({ RecipeGeneratorDialog: () => null }));
+vi.mock('../../components/ConfirmDialog', () => ({ ConfirmDialog: () => null }));
+vi.mock('@/components/ui/multi-select', () => ({
+  MultiSelect: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe('Recipes Page', () => {
+  beforeEach(() => {
+    vi.mocked(recipesHook.useRecipes).mockReturnValue({
+      recipes: [{ id: '1', name: 'Cake', servings: 1, prep_time: 0, cook_time: 0, instructions: '', ingredients: [], notes: '', is_favorite: false, tags: [], nutrition: { calories_per_serving: 0, protein_per_serving: 0, carbs_per_serving: 0, fat_per_serving: 0 } }],
+      searchQuery: '',
+      setSearchQuery: vi.fn(),
+      performSearch: vi.fn(),
+      addRecipe: vi.fn(),
+      updateRecipe: vi.fn(),
+      toggleFavorite: vi.fn(),
+      deleteRecipe: vi.fn(),
+      usingMockData: true,
+      error: null,
+    } as any);
+
+    vi.mocked(inventoryHook.useFoodInventory).mockReturnValue({ allItems: [] } as any);
+    vi.mocked(tagsHook.useTags).mockReturnValue({ allTags: [] } as any);
+  });
+
+  it('renders recipes list', () => {
+    renderWithProviders(<Recipes />);
+    expect(screen.getByText('Recipes')).toBeInTheDocument();
+    expect(screen.getByText('Cake')).toBeInTheDocument();
+  });
+});

--- a/src/tests/pages/tags-page.test.tsx
+++ b/src/tests/pages/tags-page.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import Tags from '../../pages/Tags';
+import { renderWithProviders } from '../setup';
+import * as tagsHook from '../../hooks/useTags';
+
+vi.mock('../../hooks/useTags');
+vi.mock('../../hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('../../components/Layout', () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+describe('Tags Page', () => {
+  it('renders tag list', () => {
+    vi.mocked(tagsHook.useTags).mockReturnValue({
+      tags: [{ id: 1, name: 'Spicy', color: '#fff' }],
+      searchQuery: '',
+      setSearchQuery: vi.fn(),
+      addTag: vi.fn(),
+      updateTag: vi.fn(),
+      deleteTag: vi.fn(),
+      usingMockData: true,
+      error: null,
+      isDeleting: false,
+    } as any);
+
+    renderWithProviders(<Tags />);
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByText('Spicy')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add rendering tests for Analytics, Index, Meal Prep Generator, Meals, Recipes, Tags, and NotFound pages
- add inventory page tests covering create, update, delete, and stock toggle actions
- add RecipeGeneratorDialog component test for recipe generation flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6de46cdc8329908285608ebd3ba0