### PR TITLE
Virtualized MultiSelect components with @tanstack/react-virtual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@eslint/js": "^9.32.0",
         "@playwright/test": "^1.54.2",
         "@tailwindcss/typography": "^0.5.16",
+        "@tanstack/react-virtual": "^3.13.12",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -4805,6 +4806,35 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@eslint/js": "^9.32.0",
     "@playwright/test": "^1.54.2",
     "@tailwindcss/typography": "^0.5.16",
+    "@tanstack/react-virtual": "^3.13.12",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Summary
- Implement virtualization in `MultiSelect` and `GroupedMultiSelect` using `@tanstack/react-virtual`.
- Virtualizes long lists, including a "Select All" row and grouped headers/toggles.
- Preserves existing UX: search, select/deselect, select all (global and per group), keyboard handling.

Details
- `src/components/ui/multi-select.tsx`: flat list virtualization with optional Select All row.
- `src/components/ui/grouped-multi-select.tsx`: flattened row model (group headers, group toggles, items) with virtualized rendering.
- Added dev dependency: `@tanstack/react-virtual`.

Validation
- Lint: 0 errors (warnings unaffected).
- Tests: 114/114 passing (`npm run test:run`).
- Build: successful (`npm run build`).

Notes
- No API or schema changes; UI-only performance improvement.
- Happy to tweak estimated row sizes or overscan if you want different scroll feel.
