### PR TITLE
Add mobile-friendly full-screen recipe viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import Index from "./pages/Index";
 import Recipes from "./pages/Recipes";
+import RecipeViewer from "./pages/RecipeViewer";
 import Meals from "./pages/Meals";
 import NotFound from "./pages/NotFound";
 import Planner from "./pages/Planner";
@@ -31,6 +32,7 @@ const App = () => (
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/recipes" element={<Recipes />} />
+              <Route path="/recipes/:id" element={<RecipeViewer />} />
               <Route path="/meals" element={<Meals />} />
               <Route path="/planner" element={<Planner />} />
               <Route path="/tags" element={<Tags />} />

--- a/src/pages/RecipeViewer.tsx
+++ b/src/pages/RecipeViewer.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Clock, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useRecipes } from '../hooks/useRecipes';
+import { useInventorySearch } from '../hooks/useInventorySearch';
+
+export default function RecipeViewer() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { getRecipeById } = useRecipes();
+  const { allItems } = useInventorySearch();
+
+  const recipe = id ? getRecipeById(Number(id)) : undefined;
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+
+  const toggleStep = (idx: number) => {
+    setCompletedSteps(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(idx)) {
+        newSet.delete(idx);
+      } else {
+        newSet.add(idx);
+      }
+      return newSet;
+    });
+  };
+
+  const getIngredientName = (itemId: number) =>
+    allItems.find(item => item.id === itemId)?.name || 'Unknown item';
+
+  if (!recipe) {
+    return (
+      <div className="p-4">
+        <Button
+          variant="ghost"
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-2 mb-4"
+        >
+          <ArrowLeft className="h-5 w-5" />
+          Back
+        </Button>
+        <p className="text-center">Recipe not found.</p>
+      </div>
+    );
+  }
+
+  const steps = recipe.instructions
+    .split('\n')
+    .map(step => step.trim())
+    .filter(Boolean);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <header className="p-4 border-b flex items-center justify-between">
+        <Button
+          variant="ghost"
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-2"
+        >
+          <ArrowLeft className="h-5 w-5" />
+          Back
+        </Button>
+        <h1 className="text-lg font-bold truncate max-w-[60%] text-center">
+          {recipe.name}
+        </h1>
+        <div className="w-12" />
+      </header>
+
+      <div className="px-4 py-2 text-sm text-muted-foreground flex justify-center gap-6">
+        <div className="flex items-center gap-1">
+          <Users className="h-4 w-4" />
+          {recipe.servings} servings
+        </div>
+        {recipe.total_time_minutes && (
+          <div className="flex items-center gap-1">
+            <Clock className="h-4 w-4" />
+            {recipe.total_time_minutes} min
+          </div>
+        )}
+      </div>
+
+      <Tabs defaultValue="instructions" className="flex-1 flex flex-col">
+        <TabsList className="grid w-full grid-cols-2 border-b bg-background rounded-none p-0">
+          <TabsTrigger
+            value="ingredients"
+            className="w-full py-3 text-lg rounded-none border-b-2 border-transparent data-[state=active]:border-primary"
+          >
+            Ingredients
+          </TabsTrigger>
+          <TabsTrigger
+            value="instructions"
+            className="w-full py-3 text-lg rounded-none border-b-2 border-transparent data-[state=active]:border-primary"
+          >
+            Instructions
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent
+          value="ingredients"
+          className="flex-1 overflow-y-auto p-4"
+        >
+          <ul className="space-y-3">
+            {recipe.ingredients.map((ing, i) => (
+              <li
+                key={i}
+                className="flex items-center justify-between p-4 rounded-lg border text-lg"
+              >
+                <span>{getIngredientName(ing.item_id)}</span>
+                <span className="font-medium">
+                  {ing.quantity} {ing.unit}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </TabsContent>
+
+        <TabsContent
+          value="instructions"
+          className="flex-1 overflow-y-auto p-4"
+        >
+          <ol className="space-y-4">
+            {steps.map((step, i) => (
+              <li key={i}>
+                <button
+                  onClick={() => toggleStep(i)}
+                  className={`w-full flex items-start gap-4 p-4 rounded-lg text-left border transition-colors ${
+                    completedSteps.has(i)
+                      ? 'bg-green-50 line-through opacity-60'
+                      : 'bg-background'
+                  }`}
+                >
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground font-bold">
+                    {i + 1}
+                  </span>
+                  <span className="text-lg leading-relaxed">
+                    {step.replace(/^\d+\.\s*/, '')}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ol>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+

--- a/src/pages/Recipes.tsx
+++ b/src/pages/Recipes.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Plus, Search, Clock, Users, Edit, ChevronDown, ChevronUp, Heart, Trash2, Bot, Utensils, Tag } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card } from '@/components/ui/card';
@@ -265,6 +266,11 @@ export default function Recipes() {
                         className="text-destructive hover:text-destructive"
                       >
                         <Trash2 className="h-4 w-4" />
+                      </Button>
+                      <Button asChild variant="ghost" size="sm">
+                        <Link to={`/recipes/${recipe.id}`} aria-label="Open recipe viewer">
+                          <Utensils className="h-4 w-4" />
+                        </Link>
                       </Button>
                       <Button
                         variant="ghost"

--- a/src/tests/pages/recipe-viewer-page.test.tsx
+++ b/src/tests/pages/recipe-viewer-page.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import RecipeViewer from '../../pages/RecipeViewer';
+import { renderWithProviders } from '../setup';
+import * as recipesHook from '../../hooks/useRecipes';
+import * as inventoryHook from '../../hooks/useInventorySearch';
+
+vi.mock('../../hooks/useRecipes');
+vi.mock('../../hooks/useInventorySearch');
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ id: '1' }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const mockRecipe = {
+  id: 1,
+  name: 'Pancakes',
+  servings: 2,
+  total_time_minutes: 10,
+  instructions: 'Mix\nCook',
+  ingredients: [
+    { item_id: 1, quantity: 1, unit: 'cup' },
+    { item_id: 2, quantity: 2, unit: 'pcs' },
+  ],
+  nutrition: {
+    calories_per_serving: 0,
+    protein_per_serving: 0,
+    carbs_per_serving: 0,
+    fat_per_serving: 0,
+  },
+  is_favorite: false,
+  tags: [],
+  notes: '',
+  created_at: '',
+  updated_at: '',
+};
+
+describe('RecipeViewer Page', () => {
+  beforeEach(() => {
+    vi.mocked(recipesHook.useRecipes).mockReturnValue({
+      getRecipeById: () => mockRecipe,
+    } as unknown as ReturnType<typeof recipesHook.useRecipes>);
+    vi.mocked(inventoryHook.useInventorySearch).mockReturnValue({
+      allItems: [
+        { id: 1, name: 'Flour' },
+        { id: 2, name: 'Eggs' },
+      ],
+    } as unknown as ReturnType<typeof inventoryHook.useInventorySearch>);
+  });
+
+  it('displays recipe details', () => {
+    renderWithProviders(<RecipeViewer />);
+    expect(screen.getByText('Pancakes')).toBeInTheDocument();
+    expect(screen.getByText('Mix')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add dedicated recipe viewer page with tabbed ingredients and instruction steps
- wire up routing and navigation from recipe list
- cover viewer with unit test
- refine mobile spacing and step indicators so tabs don't overlap and circles stay round
- make tab backgrounds and borders consistent on mobile

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b112f7634883298df9175a342be7f6