### PR TITLE
Handle recipe loading state to avoid false Not Found message

### DIFF
--- a/src/pages/RecipeViewer.tsx
+++ b/src/pages/RecipeViewer.tsx
@@ -11,7 +11,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 export default function RecipeViewer() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { getRecipeById } = useRecipes();
+  const { getRecipeById, loading: recipesLoading } = useRecipes();
   const { allItems } = useInventorySearch();
   const isMobile = useIsMobile();
 
@@ -79,6 +79,31 @@ export default function RecipeViewer() {
     // The hooks will automatically refetch data
     window.location.reload();
   }, []);
+
+  if (recipesLoading) {
+    return (
+      <main className="min-h-screen flex flex-col bg-background">
+        <header className="p-4 border-b flex items-center justify-between">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-2"
+            aria-label="Go back to previous page"
+          >
+            <ArrowLeft className="h-4 w-4 sm:h-5 sm:w-5" />
+            Back
+          </Button>
+          <div className="w-12" />
+        </header>
+        <div className="flex-1 flex items-center justify-center p-4">
+          <div className="text-center space-y-2">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+            <p className="text-sm text-muted-foreground">Loading recipe...</p>
+          </div>
+        </div>
+      </main>
+    );
+  }
 
   if (!recipe) {
     const isInvalidId = id && isNaN(Number(id));

--- a/src/tests/pages/recipe-viewer-page.test.tsx
+++ b/src/tests/pages/recipe-viewer-page.test.tsx
@@ -45,6 +45,7 @@ describe('RecipeViewer Page', () => {
   beforeEach(() => {
     vi.mocked(recipesHook.useRecipes).mockReturnValue({
       getRecipeById: () => mockRecipe,
+      loading: false,
     } as unknown as ReturnType<typeof recipesHook.useRecipes>);
     vi.mocked(inventoryHook.useInventorySearch).mockReturnValue({
       allItems: [
@@ -86,6 +87,15 @@ describe('RecipeViewer Page', () => {
     renderWithProviders(<RecipeViewer />);
     // Check if mobile-specific styling is applied
     expect(screen.getByLabelText('Go back to previous page')).toBeInTheDocument();
+  });
+
+  it('displays loading state when recipes are loading', () => {
+    vi.mocked(recipesHook.useRecipes).mockReturnValue({
+      getRecipeById: () => undefined,
+      loading: true,
+    } as unknown as ReturnType<typeof recipesHook.useRecipes>);
+    renderWithProviders(<RecipeViewer />);
+    expect(screen.getByText('Loading recipe...')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- show loading spinner while recipe data loads
- add tests for recipe viewer loading state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21dd3cff883298a70d94dad372ae9