### PR TITLE
Redesign of recipe card

### DIFF
--- a/src/pages/RecipeViewer.tsx
+++ b/src/pages/RecipeViewer.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Clock, Users, AlertCircle, RotateCcw } from 'lucide-react';
+import { ArrowLeft, Clock, Users, AlertCircle, RotateCcw, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -11,7 +11,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 export default function RecipeViewer() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { getRecipeById } = useRecipes();
+  const { getRecipeById, loading } = useRecipes();
   const { allItems } = useInventorySearch();
   const isMobile = useIsMobile();
 
@@ -79,6 +79,33 @@ export default function RecipeViewer() {
     // The hooks will automatically refetch data
     window.location.reload();
   }, []);
+
+  // Loading screen for smoother transition into full-screen cook mode
+  if (loading) {
+    return (
+      <main className="min-h-screen flex flex-col bg-background">
+        <header className="p-3 sm:p-4 border-b flex items-center justify-between">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-1 sm:gap-2"
+            size={isMobile ? "sm" : "default"}
+            aria-label="Go back to previous page"
+          >
+            <ArrowLeft className="h-4 w-4 sm:h-5 sm:w-5" />
+            <span className="hidden sm:inline">Back</span>
+          </Button>
+          <div className="w-8 sm:w-12" />
+        </header>
+        <div className="flex-1 flex items-center justify-center p-6">
+          <div className="text-center space-y-3" role="status" aria-busy="true">
+            <Loader2 className="h-8 w-8 sm:h-10 sm:w-10 animate-spin text-primary mx-auto" />
+            <p className="text-sm sm:text-base text-muted-foreground">Loading recipe…</p>
+          </div>
+        </div>
+      </main>
+    );
+  }
 
   if (!recipe) {
     const isInvalidId = id && isNaN(Number(id));
@@ -322,4 +349,3 @@ export default function RecipeViewer() {
     </main>
   );
 }
-


### PR DESCRIPTION
# Mobile recipe cards redesign + smooth cook mode loading

## Summary

Redesign mobile recipe cards to surface only essential actions and highlight scannable info.
Add a full‑screen loading state when entering Cook Mode for a smoother transition.

## Changes

### Recipes page (`src/pages/Recipes.tsx`):
- **Actions**: Reduced to 4 and reordered — Cook (primary, first), Heart, Edit, Delete. Removed viewer toggle and expand/collapse.
- **Header**: Larger, bolder title; servings/time emphasized; cost‑per‑serving badge when available; improved tag presentation/spacings.
- **Nutrition**: Replaced inline chips with a compact 2×2 metric grid card (calories, protein, carbs, fat) with color cues.
- **Summary**: New "Ready to cook" block showing ingredient count and step count, with optional notes.
- **Cleanup**: Removed expand/collapse state/handlers/icons and unused inventory search usage.

### Recipe viewer (`src/pages/RecipeViewer.tsx`):
- **Loading screen**: Shows centered spinner and "Loading recipe…" while recipes load (uses `useRecipes().loading`).
- Back button remains available; Not‑found is shown only after loading completes.

## UX Impact

- **Mobile‑first scanning**: Clear hierarchy; key info (title + nutrition) is prominent.
- **Primary action first**: Cook is the first button for faster entry.
- **Smoother transition into cook mode**: Accessible labels on actions.

## Notes

- No data/model changes or migrations. UI only.
- Cost badge only shows when `cost_per_serving > 0`; notes shown when present.

## How to test

1. Visit Recipes and confirm each card shows the 4 actions with Cook first and the enhanced nutrition/summary.
2. Tap Cook; observe the full‑screen loader before the viewer appears.
3. Verify cost badge only shows when cost_per_serving > 0; notes shown when present.

## Branch/commits

**Branch**: `redesign-of-recipe-card` (pushed)

**Commits**:
- `feat(recipes): mobile-friendly recipe cards with Cook-first actions, enhanced nutrition, and summary`
- `feat(viewer): add full-screen loading state for smoother cook mode transition`

## Files Changed

- `src/pages/Recipes.tsx` - Major redesign of recipe cards (70 additions, 117 deletions)
- `src/pages/RecipeViewer.tsx` - Added loading state (29 additions, 3 deletions)

## Compare URL

https://github.com/kosiuzo/uzo-food-tracking/compare/main...redesign-of-recipe-card?expand=1
