### PR TITLE
Use password auth in production

### DIFF
--- a/src/components/AuthDialog.tsx
+++ b/src/components/AuthDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useToast } from '@/hooks/use-toast'
-import { Loader2, Mail } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 
 interface AuthDialogProps {
   open: boolean
@@ -19,14 +19,11 @@ interface AuthDialogProps {
 }
 
 const ALLOWED_EMAIL = import.meta.env.VITE_ALLOWED_EMAIL || 'kosiuzodinma@gmail.com'
-const IS_DEVELOPMENT = import.meta.env.MODE === 'development'
-
 export const AuthDialog = ({ open, onOpenChange }: AuthDialogProps) => {
   const [loading, setLoading] = useState(false)
   const [email, setEmail] = useState(ALLOWED_EMAIL)
   const [password, setPassword] = useState('')
-  const [emailSent, setEmailSent] = useState(false)
-  const { signInWithMagicLink, signInWithPassword } = useAuth()
+  const { signInWithPassword } = useAuth()
   const { toast } = useToast()
 
   const handleSignIn = async (e: React.FormEvent) => {
@@ -34,47 +31,28 @@ export const AuthDialog = ({ open, onOpenChange }: AuthDialogProps) => {
 
     setLoading(true)
 
-    if (IS_DEVELOPMENT) {
-      const { error } = await signInWithPassword(email, password)
-      if (error) {
-        toast({
-          title: 'Error signing in',
-          description: error.message,
-          variant: 'destructive',
-        })
-      } else {
-        toast({
-          title: 'Success',
-          description: 'Signed in successfully!',
-        })
-        onOpenChange(false)
-        resetForm()
-      }
-      setLoading(false)
+    const { error } = await signInWithPassword(email, password)
+    if (error) {
+      toast({
+        title: 'Error signing in',
+        description: error.message,
+        variant: 'destructive',
+      })
     } else {
-      const { error } = await signInWithMagicLink(email)
-      if (error) {
-        toast({
-          title: 'Error sending magic link',
-          description: error.message,
-          variant: 'destructive',
-        })
-        setLoading(false)
-      } else {
-        setEmailSent(true)
-        setLoading(false)
-        toast({
-          title: 'Magic link sent!',
-          description: 'Check your email for the login link.',
-        })
-      }
+      toast({
+        title: 'Success',
+        description: 'Signed in successfully!',
+      })
+      onOpenChange(false)
+      resetForm()
     }
+
+    setLoading(false)
   }
 
   const resetForm = () => {
     setEmail(ALLOWED_EMAIL)
     setPassword('')
-    setEmailSent(false)
   }
 
   return (
@@ -86,63 +64,39 @@ export const AuthDialog = ({ open, onOpenChange }: AuthDialogProps) => {
         <DialogHeader>
           <DialogTitle>Access Required</DialogTitle>
           <DialogDescription>
-            {IS_DEVELOPMENT
-              ? 'Development mode - Sign in with your password.'
-              : emailSent
-              ? 'We sent you a magic link! Check your email to sign in.'
-              : 'This application is restricted to authorized users. Enter your email to receive a magic link.'}
+            Sign in with your email and password to continue.
           </DialogDescription>
         </DialogHeader>
 
-        {!IS_DEVELOPMENT && emailSent ? (
-          <div className="space-y-4 mt-4">
-            <div className="flex items-center justify-center p-6 bg-muted rounded-lg">
-              <Mail className="h-12 w-12 text-muted-foreground" />
-            </div>
-            <p className="text-sm text-center text-muted-foreground">
-              Click the link in your email to sign in. You can close this dialog.
-            </p>
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={resetForm}
-            >
-              Send another link
-            </Button>
+        <form onSubmit={handleSignIn} className="space-y-4 mt-4">
+          <div className="space-y-2">
+            <Label htmlFor="signin-email">Email</Label>
+            <Input
+              id="signin-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={loading}
+            />
           </div>
-        ) : (
-          <form onSubmit={handleSignIn} className="space-y-4 mt-4">
-            <div className="space-y-2">
-              <Label htmlFor="signin-email">Email</Label>
-              <Input
-                id="signin-email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                disabled={loading}
-              />
-            </div>
-            {IS_DEVELOPMENT && (
-              <div className="space-y-2">
-                <Label htmlFor="signin-password">Password</Label>
-                <Input
-                  id="signin-password"
-                  type="password"
-                  placeholder="Enter your password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  disabled={loading}
-                />
-              </div>
-            )}
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {IS_DEVELOPMENT ? 'Sign In' : 'Send Magic Link'}
-            </Button>
-          </form>
-        )}
+          <div className="space-y-2">
+            <Label htmlFor="signin-password">Password</Label>
+            <Input
+              id="signin-password"
+              type="password"
+              placeholder="Enter your password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              disabled={loading}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Sign In
+          </Button>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -6,7 +6,6 @@ interface AuthContextType {
   user: User | null
   session: Session | null
   loading: boolean
-  signInWithMagicLink: (email: string) => Promise<{ error: AuthError | null }>
   signInWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>
   signOut: () => Promise<{ error: AuthError | null }>
 }
@@ -51,16 +50,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return () => subscription.unsubscribe()
   }, [])
 
-  const signInWithMagicLink = async (email: string) => {
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
-      },
-    })
-    return { error }
-  }
-
   const signInWithPassword = async (email: string, password: string) => {
     const { error } = await supabase.auth.signInWithPassword({
       email,
@@ -78,7 +67,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     user,
     session,
     loading,
-    signInWithMagicLink,
     signInWithPassword,
     signOut,
   }


### PR DESCRIPTION
## Summary
- update AuthDialog to always require email and password sign in
- remove unused magic link authentication flow from the auth context

## Testing
- npx tsc --noEmit
- npm run lint
- npm run test:run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ee55ff3c8329b62aed0c03064c3c