### PR TITLE
Fix Eastern Time handling for meal log dates

### DIFF
--- a/src/components/MealRelogDialog.tsx
+++ b/src/components/MealRelogDialog.tsx
@@ -10,7 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { MealLog } from '../types';
-import { getTodayLocalDate } from '@/lib/utils';
+import { getTodayLocalDate, formatAppDateForDisplay } from '@/lib/utils';
 import { useDebounce, searchMealLogs } from '@/lib/search';
 
 interface MealRelogDialogProps {
@@ -183,8 +183,7 @@ export function MealRelogDialog({ open, onOpenChange, mealLogs, onRelogMeal }: M
     const today = getTodayLocalDate();
     if (dateString === today) return 'Today';
 
-    const date = new Date(dateString + 'T00:00:00');
-    return date.toLocaleDateString();
+    return formatAppDateForDisplay(dateString);
   };
 
   const steps = [

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Layout } from '../components/Layout';
 import { supabase } from '../lib/supabase';
+import { formatAppDateForDisplay, parseAppDate, formatDateToIsoString } from '@/lib/utils';
 
 interface AnalyticsData {
   daily_averages: {
@@ -183,7 +184,7 @@ export default function Analytics() {
 
   // Format date for display
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return formatAppDateForDisplay(dateString, {
       weekday: 'short',
       month: 'short',
       day: 'numeric'
@@ -192,17 +193,23 @@ export default function Analytics() {
 
   // Format week period for display
   const formatWeekPeriod = (weekStart: string) => {
-    const start = new Date(weekStart);
-    const end = new Date(start);
-    end.setDate(start.getDate() + 6);
+    const start = formatAppDateForDisplay(weekStart, {
+      month: 'short',
+      day: 'numeric'
+    });
+    const endDate = parseAppDate(weekStart);
+    endDate.setUTCDate(endDate.getUTCDate() + 6);
+    const end = formatAppDateForDisplay(formatDateToIsoString(endDate), {
+      month: 'short',
+      day: 'numeric'
+    });
 
-    return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} - ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+    return `${start} - ${end}`;
   };
 
   // Format month period for display
   const formatMonthPeriod = (monthStart: string) => {
-    const date = new Date(monthStart);
-    return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    return formatAppDateForDisplay(monthStart, { month: 'long', year: 'numeric' });
   };
 
   // Get period label for display

--- a/src/pages/Meals.tsx
+++ b/src/pages/Meals.tsx
@@ -19,7 +19,7 @@ import { useToast } from '@/hooks/use-toast';
 import { MealLog } from '../types';
 import { logger } from '@/lib/logger';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { getTodayLocalDate, getYesterdayLocalDate } from '@/lib/utils';
+import { getTodayLocalDate, getYesterdayLocalDate, formatAppDateForDisplay, shiftAppDate } from '@/lib/utils';
 import { getSettings } from '@/lib/settings-utils';
 
 export default function Meals() {
@@ -87,9 +87,7 @@ export default function Meals() {
     } else if (eatenOn === yesterdayLocal) {
       return 'Yesterday';
     } else {
-      // Format the date string for display
-      const date = new Date(eatenOn + 'T00:00:00'); // Add time to avoid timezone issues
-      return date.toLocaleDateString();
+      return formatAppDateForDisplay(eatenOn);
     }
   };
 
@@ -101,9 +99,8 @@ export default function Meals() {
         setViewMode('day');
         break;
       case 'Yesterday': {
-        const yesterday = new Date();
-        yesterday.setDate(yesterday.getDate() - 1);
-        goToDate(yesterday.toISOString().split('T')[0]);
+        const yesterday = shiftAppDate(getTodayLocalDate(), { days: -1 });
+        goToDate(yesterday);
         setViewMode('day');
         break;
       }


### PR DESCRIPTION
## Summary
- add Eastern Time aware date helpers and formatting utilities
- update date navigation and analytics views to use the canonical timezone formatting
- adjust meal log displays and dialogs to rely on the shared helpers to avoid UTC drift

## Testing
- npm run lint
- npx tsc --noEmit
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68d9784427c483299f290f9ea3d0b13d