### PR TITLE
Document recipe search vector usage

### DIFF
--- a/docs/openapi-3.1.yaml
+++ b/docs/openapi-3.1.yaml
@@ -175,7 +175,9 @@ paths:
       operationId: getMealLogs
       summary: Find and retrieve specific meals
       description: 'Find specific meals by ingredients/content. Use search_vector=fts.chicken for "meals with chicken". For
-        re-logging: GET original meal, POST with new eaten_on. For analytics use cache endpoints instead.'
+        re-logging: GET original meal, POST with new eaten_on. For analytics use cache endpoints instead. Search requests
+        tap into the meal_logs.search_vector column maintained by the update_meal_logs_search_vector trigger and reuse the
+        same pg_trgm GIN indexes as the app for fuzzy substring matching on meal_name, notes, and items.'
       parameters:
         - name: select
           in: query
@@ -243,8 +245,10 @@ paths:
           in: query
           required: false
           description: 'Use for semantic food searches like "meals with chicken", "breakfast with eggs", "dinner without meat".
-            Searches across meal names, ingredients, and notes. Format: fts.chicken for single ingredient,
-            fts.chicken&vegetables for AND, fts.breakfast|lunch for OR.'
+            Searches across meal names, ingredients, and notes via the maintained meal_logs.search_vector column. Format:
+            fts.chicken for single ingredient, fts.chicken&vegetables for AND, fts.breakfast|lunch for OR. Combines with the
+            pg_trgm-backed ilike filters on meal_name/notes/items for substring-style fuzzy matching when you need "contains"
+            behavior.'
           schema:
             type: string
           examples:
@@ -419,6 +423,11 @@ paths:
   /recipes:
     get:
       operationId: getRecipes
+      summary: Search recipes by name, ingredients, or notes
+      description: >
+        Use for recipe discovery like "find vegetarian pasta", "show chicken soup ideas", "dishes with roasted vegetables".
+        Requests leverage the recipes.search_vector column maintained by the update_recipes_search_vector trigger so results
+        mirror the in-app Supabase full-text search.
       parameters:
         - name: select
           in: query
@@ -446,6 +455,29 @@ paths:
           required: false
           schema:
             type: string
+        - name: search_vector
+          in: query
+          required: false
+          description: >
+            Use Supabase full-text search for intent-style queries like "vegetarian dinner", "quick breakfast bowls" or "salmon
+            without dairy". Searches across recipe names, instructions, notes, ingredient_list text, and feedback comments
+            through the maintained recipes.search_vector column so it stays in sync with trigger updates. Combine with other
+            filters as needed, e.g. ?user_id=eq.{uuid}&search_vector=fts.vegetarian&search_vector=fts.quinoa for AND matches.
+          schema:
+            type: string
+          examples:
+            single_term:
+              summary: Single ingredient or concept
+              value: fts.vegetarian
+              description: "Find recipes mentioning 'vegetarian'. Query: ?user_id=eq.{uuid}&search_vector=fts.vegetarian"
+            multi_term_and:
+              summary: Require multiple ingredients
+              value: fts.chicken&rice
+              description: "Find recipes mentioning both chicken AND rice. Query: ?user_id=eq.{uuid}&search_vector=fts.chicken&rice"
+            exclude_term:
+              summary: Exclude an ingredient
+              value: fts.soup&!cream
+              description: "Find soups that do not mention cream. Query: ?user_id=eq.{uuid}&search_vector=fts.soup&!cream"
         - name: is_favorite
           in: query
           required: false


### PR DESCRIPTION
## Summary
- add summary and description for the recipes endpoint highlighting the maintained recipes.search_vector column
- document the search_vector query parameter and examples so recipe FTS mirrors the in-app behavior

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e1b4919bb48329bb89df39186b6d5f